### PR TITLE
docs: fix typo in SetDownstreamResponseHeader.yaml

### DIFF
--- a/root/openapi/inventory/schemas/SetDownstreamResponseHeader.yaml
+++ b/root/openapi/inventory/schemas/SetDownstreamResponseHeader.yaml
@@ -1,5 +1,5 @@
 type: object
-title: SetDownstreamRequestHeader
+title: SetDownstreamResponseHeader
 description: |-
   Downstreamへの通信のHTTP レスポンスヘッダーの設定を行うためのアクション。
   動作は、セキュリティ上安全なUpsert（存在すれば更新し、存在しなければ新規作成する）。
@@ -9,7 +9,7 @@ required:
 properties:
   type:
     type: string
-    enum: [setDownstreamRequestHeader]
+    enum: [setDownstreamResponseHeader]
   name:
     type: string
     description: |-


### PR DESCRIPTION
すいません、さっきの打ち合わせ中に発見し話題になったミスの修正です。
downstream request -> down stream response