### PR TITLE
feat: add missing actions and document service idleTimeout=0

### DIFF
--- a/root/openapi/inventory/schemas/ReturnStaticText.yaml
+++ b/root/openapi/inventory/schemas/ReturnStaticText.yaml
@@ -1,0 +1,22 @@
+type: object
+title: ReturnStaticText
+required:
+  - type
+  - content
+  - status
+description: |-
+  静的なテキストを返却するアクション。
+  指定されたステータスコードとコンテンツでレスポンスを返し、リクエスト処理を終了します。
+properties:
+  type:
+    type: string
+    enum: [returnStaticText]
+  content:
+    type: string
+    description: レスポンスボディとして返却する固定の文字列。
+    example: "User-agent: *\nDisallow: /"
+  status:
+    type: integer
+    description: HTTPステータスコード。
+    example: 200
+additionalProperties: false

--- a/root/openapi/inventory/schemas/Service.yaml
+++ b/root/openapi/inventory/schemas/Service.yaml
@@ -75,7 +75,7 @@ properties:
         description: オンデマンド起動とするか否か。トリガはコンシューマ側の最初のペイロード。デフォルトは true
       idleTimeout:
         type: integer
-        description: 指定された秒数通信がない状態が続くとサービスをシャットダウンする。 ondemandStart が true の場合のみ有効
+        description: 指定された秒数通信がない状態が続くとプロバイダをシャットダウンする。 ondemandStart が true の場合のみ有効。 ただし、0は自動シャットダウンしない。
       image:
         type: string
         description: コンテナイメージのパスとタグ


### PR DESCRIPTION
スキーマの修正です。
- ReturnStaticTextアクションのドキュメントがなかったので追加
- プロバイダー自動停止のidle timeoutで0なら自動停止しない