### PR TITLE
feat: introduce config for OIDC dialect variants

### DIFF
--- a/root/openapi/inventory/schemas/RequireAuthentication.yaml
+++ b/root/openapi/inventory/schemas/RequireAuthentication.yaml
@@ -54,4 +54,9 @@ properties:
     description: |-
       OIDC IdP のトークンエンドポイントのURLを指定します。
     example: https://auth.example.com/auth/realms/chip-in/protocol/openid-connect/token
+  oidcDialect:
+    type: string
+    enum: [google]
+    description: |-
+      OIDCプロバイダ毎の特殊な振る舞いに対応します。
 additionalProperties: false


### PR DESCRIPTION
GoogleのOIDC方言で動作を変えるための設定値です。
OIDCプロバイダの方言になるポイントが多様なため、設定項目毎の設定値で吸収しようとすると、大変難しい設定になってしまうので、プロバイダを設定する方法にしました。